### PR TITLE
Inline map and graph HTML into exported report via srcdoc iframes

### DIFF
--- a/dashcam_investigator/core/generate_report.py
+++ b/dashcam_investigator/core/generate_report.py
@@ -2,9 +2,9 @@
 Render the standalone HTML investigation report.
 
 The report shares Jinja templates and CSS with the in-app UI so the two
-look like one product. CSS and SVG icons are inlined into the rendered
-HTML; map / speed-graph HTMLs stay as separate files referenced via
-relative iframe srcs (the user normally ships the whole project dir).
+look like one product. CSS, SVG icons, and map/speed-graph HTMLs are all
+inlined into the rendered HTML so the exported file is fully self-contained
+— no sibling directories required.
 
 Public surface — preserved across the rewrite:
     generate_report(project_object: ProjectStructure) -> Path
@@ -13,7 +13,6 @@ Public surface — preserved across the rewrite:
 from __future__ import annotations
 
 import logging
-import os
 from datetime import datetime
 from pathlib import Path
 
@@ -41,7 +40,7 @@ def generate_report(project_object: ProjectStructure) -> Path:
     output_file.parent.mkdir(parents=True, exist_ok=True)
 
     video_info = {v.name: _collect_info(v) for v in flagged}
-    video_iframes = {v.name: _collect_iframes(v, output_file.parent) for v in flagged}
+    video_inline = {v.name: _collect_inline_html(v) for v in flagged}
 
     logger.debug("Rendering report for %d flagged video(s)", len(flagged))
     html = render(
@@ -49,7 +48,7 @@ def generate_report(project_object: ProjectStructure) -> Path:
         case=case,
         flagged=flagged,
         video_info=video_info,
-        video_iframes=video_iframes,
+        video_inline=video_inline,
         generated_date=datetime.now().strftime("%Y-%m-%d %H:%M"),
         app=False,
     )
@@ -92,24 +91,19 @@ def _collect_info(video: FileAttributes) -> dict[str, str]:
     return info
 
 
-def _collect_iframes(video: FileAttributes, report_dir: Path) -> dict[str, str]:
-    """Compute relative iframe URLs for the map (output_files[0]) and graph ([1])."""
-    iframes: dict[str, str] = {}
-    if video.output_files and len(video.output_files) > 0:
-        iframes["map"] = _rel_url(video.output_files[0], report_dir)
-    if video.output_files and len(video.output_files) > 1:
-        iframes["graph"] = _rel_url(video.output_files[1], report_dir)
-    return iframes
-
-
-def _rel_url(target: str, base: Path) -> str:
-    """Return a Posix-style URL pointing at `target` relative to `base`."""
-    try:
-        rel = os.path.relpath(target, str(base))
-    except ValueError:
-        # Different drives on Windows — fall back to the absolute path.
-        return Path(target).as_posix()
-    return Path(rel).as_posix()
+def _collect_inline_html(video: FileAttributes) -> dict[str, str]:
+    """Read map (output_files[0]) and graph (output_files[1]) HTML and return contents."""
+    inline: dict[str, str] = {}
+    paths = {"map": 0, "graph": 1}
+    for key, idx in paths.items():
+        if video.output_files and len(video.output_files) > idx:
+            path = Path(video.output_files[idx])
+            if path.is_file():
+                try:
+                    inline[key] = path.read_text(encoding="utf-8")
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("Could not read %s file %s: %s", key, path, exc)
+    return inline
 
 
 def _fmt(value) -> str:

--- a/dashcam_investigator/gui/assets/templates/report.html
+++ b/dashcam_investigator/gui/assets/templates/report.html
@@ -1,13 +1,12 @@
-{# Standalone HTML report. Self-contained: tokens, base, components and
-   report-specific CSS are all inlined; icons are inline SVGs. The iframe
-   srcs are file paths relative to the report file, so the report stays
-   portable as long as it ships alongside the project's Maps/Graphs dirs.
+{# Standalone HTML report. Fully self-contained: tokens, base, components,
+   report-specific CSS, icons, and map/graph HTML are all inlined. The
+   exported file needs no sibling directories to display correctly.
 
    Required context:
        case               — ProjectInfo (case_name, investigator_name, …)
        flagged            — list[FileAttributes]
        video_info         — dict[name, dict[label, value]]
-       video_iframes      — dict[name, {map: rel_path, graph: rel_path}]
+       video_inline       — dict[name, {map: html_str, graph: html_str}]
        generated_date     — formatted timestamp string
 #}
 <!doctype html>
@@ -82,17 +81,17 @@
                 <p>{{ video.notes if video.notes else '(no notes)' }}</p>
             </section>
 
-            {% set iframes = video_iframes.get(video.name, {}) %}
-            {% if iframes.map %}
+            {% set inline = video_inline.get(video.name, {}) %}
+            {% if inline.map %}
             <section class="report-frame">
                 <div class="report-frame-label">GPS track</div>
-                <iframe src="{{ iframes.map }}" loading="lazy" title="Map for {{ video.name }}"></iframe>
+                <iframe srcdoc="{{ inline.map }}" loading="lazy" title="Map for {{ video.name }}"></iframe>
             </section>
             {% endif %}
-            {% if iframes.graph %}
+            {% if inline.graph %}
             <section class="report-frame">
                 <div class="report-frame-label">Speed profile</div>
-                <iframe src="{{ iframes.graph }}" loading="lazy" title="Speed graph for {{ video.name }}"></iframe>
+                <iframe srcdoc="{{ inline.graph }}" loading="lazy" title="Speed graph for {{ video.name }}"></iframe>
             </section>
             {% endif %}
         </article>

--- a/tests/test_generate_report.py
+++ b/tests/test_generate_report.py
@@ -290,7 +290,7 @@ class TestGenerateReport:
         assert output_file.exists()
 
     def test_generate_report_includes_iframes(self, create_project_with_flagged_videos):
-        """Report embeds the map + graph HTMLs as iframes per flagged video."""
+        """Report embeds the map + graph HTMLs as srcdoc iframes per flagged video."""
         project = create_project_with_flagged_videos(num_flagged=1)
         output_file = generate_report(project)
 
@@ -300,23 +300,26 @@ class TestGenerateReport:
         assert content.count("<iframe") >= 2
         assert 'title="Map for video0.mp4"' in content
         assert 'title="Speed graph for video0.mp4"' in content
+        # Iframes must use srcdoc (inline), not external src paths.
+        assert "srcdoc=" in content
+        assert 'src="../Maps/' not in content
+        assert 'src="../Graphs/' not in content
 
-    def test_generate_report_iframe_srcs_are_relative(
+    def test_generate_report_iframes_are_self_contained(
         self, create_project_with_flagged_videos
     ):
-        """Iframe srcs must be relative so the report ships with its sibling dirs."""
+        """Map and graph HTML are inlined via srcdoc so the report needs no sibling files."""
         project = create_project_with_flagged_videos(num_flagged=1)
         output_file = generate_report(project)
 
         content = Path(output_file).read_text()
 
-        # ../Maps/... and ../Graphs/... are produced because the report lives
-        # under Reports/ and the assets are siblings of Reports/.
-        assert "../Maps/video0_map.html" in content
-        assert "../Graphs/video0_speed_graph.html" in content
-        # And no absolute file paths leaking into the HTML.
-        assert "/tmp/" not in content
-        assert "C:\\" not in content
+        # The map file content ("<html>Map</html>") must appear HTML-escaped inside srcdoc.
+        assert "&lt;html&gt;Map&lt;/html&gt;" in content
+        assert "&lt;html&gt;Graph&lt;/html&gt;" in content
+        # No relative file-system paths in the output.
+        assert "../Maps/" not in content
+        assert "../Graphs/" not in content
 
     def test_generate_report_video_links(self, create_project_with_flagged_videos):
         """Each flagged video gets a clickable row that selects its pane."""

--- a/tests/test_report_template.py
+++ b/tests/test_report_template.py
@@ -63,30 +63,36 @@ def test_report_template_does_not_load_external_assets() -> None:
     assert "qwebchannel.js" not in html
 
 
-# --- _rel_url helper -------------------------------------------------
-def test_rel_url_returns_posix_relative_to_base(tmp_path: Path) -> None:
-    base = tmp_path / "Reports"
-    base.mkdir()
-    target = tmp_path / "Maps" / "vid_map.html"
-    target.parent.mkdir()
-    target.write_text("<html/>")
+# --- _collect_inline_html helper -------------------------------------
+def test_collect_inline_html_reads_map_and_graph(tmp_path: Path) -> None:
+    from dashcam_investigator.project_manager.project_datatypes import FileAttributes
 
-    rel = report_module._rel_url(str(target), base)
-    assert rel == "../Maps/vid_map.html"
-    assert "\\" not in rel
+    map_file = tmp_path / "vid_map.html"
+    graph_file = tmp_path / "vid_graph.html"
+    map_file.write_text("<html>Map</html>")
+    graph_file.write_text("<html>Graph</html>")
+
+    video_path = tmp_path / "v.mp4"
+    video_path.write_text("x")
+    video = FileAttributes(file_path=video_path)
+    video.output_files = [str(map_file), str(graph_file)]
+
+    result = report_module._collect_inline_html(video)
+    assert result["map"] == "<html>Map</html>"
+    assert result["graph"] == "<html>Graph</html>"
 
 
-def test_rel_url_handles_absolute_target_outside_tree(tmp_path: Path) -> None:
-    """Same-drive but elsewhere — still resolved to a posix relative path."""
-    base = tmp_path / "a" / "Reports"
-    base.mkdir(parents=True)
-    target = tmp_path / "b" / "x.html"
-    target.parent.mkdir()
+def test_collect_inline_html_skips_missing_files(tmp_path: Path) -> None:
+    from dashcam_investigator.project_manager.project_datatypes import FileAttributes
 
-    rel = report_module._rel_url(str(target), base)
-    # Cross-tree relative: should walk back up + over.
-    assert rel.startswith("../") or rel.startswith("..")
-    assert rel.endswith("x.html")
+    video_path = tmp_path / "v.mp4"
+    video_path.write_text("x")
+    video = FileAttributes(file_path=video_path)
+    video.output_files = [str(tmp_path / "missing_map.html"), str(tmp_path / "missing_graph.html")]
+
+    result = report_module._collect_inline_html(video)
+    assert "map" not in result
+    assert "graph" not in result
 
 
 # --- _collect_info ---------------------------------------------------

--- a/tests/test_report_template.py
+++ b/tests/test_report_template.py
@@ -88,7 +88,10 @@ def test_collect_inline_html_skips_missing_files(tmp_path: Path) -> None:
     video_path = tmp_path / "v.mp4"
     video_path.write_text("x")
     video = FileAttributes(file_path=video_path)
-    video.output_files = [str(tmp_path / "missing_map.html"), str(tmp_path / "missing_graph.html")]
+    video.output_files = [
+        str(tmp_path / "missing_map.html"),
+        str(tmp_path / "missing_graph.html"),
+    ]
 
     result = report_module._collect_inline_html(video)
     assert "map" not in result


### PR DESCRIPTION
Previously the report referenced Maps/ and Graphs/ directories via
relative iframe src paths, requiring those folders to travel with the
file. Now _collect_inline_html() reads each output HTML file and the
template embeds the content directly in srcdoc attributes, producing a
single portable HTML file with no external dependencies.

- Replace _collect_iframes / _rel_url in generate_report.py with
  _collect_inline_html that reads file contents
- Switch report.html iframes from src= to srcdoc= (Jinja2 autoescape
  handles attribute-encoding automatically)
- Update tests to assert srcdoc content rather than relative src paths

https://claude.ai/code/session_01WYzTVG4E8pxCKBUaDCKieK