### PR TITLE
Add Linux compatibility and tar.gz + AppImage build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,13 +132,23 @@ jobs:
         run: |
           uv run python -c "import dashcam_investigator; print('Package imported successfully')"
 
-  release:
-    name: Create Release
-    runs-on: windows-latest
+  package:
+    name: Package (${{ matrix.os }})
     needs: [lint-and-format, test, build]
     if: github.event_name == 'workflow_dispatch' && inputs.create_release == true
-    permissions:
-      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows-latest
+            artifact_name: DashcamInvestigator-windows-x86_64
+            artifact_path: dist/DashcamInvestigator-windows-x86_64.zip
+          - os: ubuntu-latest
+            artifact_name: DashcamInvestigator-linux-x86_64
+            artifact_path: |
+              dist/DashcamInvestigator-linux-x86_64.tar.gz
+              dist/DashcamInvestigator-x86_64.AppImage
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -157,18 +167,72 @@ jobs:
         run: |
           uv sync --frozen --dev
 
-      - name: Build Windows executable
+      - name: Install Linux system packages
+        if: matrix.os == 'ubuntu-latest'
         run: |
-          uv run pyinstaller --clean --onefile --windowed --name DashcamInvestigator dashcam_investigator/__main__.py
+          sudo apt-get update
+          # ExifTool (Perl-based on Linux), GStreamer codecs for QMediaPlayer,
+          # and the FUSE runtime appimagetool needs to assemble the AppImage.
+          sudo apt-get install -y --no-install-recommends \
+            libimage-exiftool-perl \
+            gstreamer1.0-libav \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-ugly \
+            libfuse2 \
+            file
+
+      - name: Build with PyInstaller
+        run: |
+          uv run pyinstaller --noconfirm --clean DashcamInvestigator.spec
+
+      - name: Package Windows zip
+        if: matrix.os == 'windows-latest'
+        shell: pwsh
+        run: |
+          Compress-Archive -Path dist/DashcamInvestigator/* -DestinationPath dist/DashcamInvestigator-windows-x86_64.zip
+
+      - name: Package Linux tar.gz
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          tar -czf dist/DashcamInvestigator-linux-x86_64.tar.gz -C dist DashcamInvestigator
+
+      - name: Build Linux AppImage
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          curl -L -o /tmp/appimagetool \
+            https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage
+          chmod +x /tmp/appimagetool
+          sudo install /tmp/appimagetool /usr/local/bin/appimagetool
+          ./packaging/linux/build_appimage.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: ${{ matrix.artifact_path }}
+          if-no-files-found: error
+
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    needs: [package]
+    if: github.event_name == 'workflow_dispatch' && inputs.create_release == true
+    permissions:
+      contents: write
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
 
       - name: Determine release version
         id: version
-        shell: bash
         run: |
           if [ -n "${{ inputs.release_version }}" ]; then
             echo "version=${{ inputs.release_version }}" >> $GITHUB_OUTPUT
           else
-            echo "version=v$(date +'%Y.%m.%d-%H%M%S')" >> $GITHUB_OUTPUT
+            echo "version=v$(date -u +'%Y.%m.%d-%H%M%S')" >> $GITHUB_OUTPUT
           fi
 
       - name: Create Release
@@ -179,7 +243,9 @@ jobs:
           draft: false
           prerelease: false
           files: |
-            dist/DashcamInvestigator.exe
+            artifacts/DashcamInvestigator-windows-x86_64/DashcamInvestigator-windows-x86_64.zip
+            artifacts/DashcamInvestigator-linux-x86_64/DashcamInvestigator-linux-x86_64.tar.gz
+            artifacts/DashcamInvestigator-linux-x86_64/DashcamInvestigator-x86_64.AppImage
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,8 @@ MANIFEST
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
 *.spec
+# Our hand-written cross-platform spec is the build source of truth, so keep it.
+!DashcamInvestigator.spec
 
 # Installer logs
 pip-log.txt

--- a/DashcamInvestigator.spec
+++ b/DashcamInvestigator.spec
@@ -1,0 +1,78 @@
+# PyInstaller spec for Dashcam Investigator. Cross-platform: works on Windows,
+# Linux, and macOS. Build with: `uv run pyinstaller DashcamInvestigator.spec`.
+#
+# Output: dist/DashcamInvestigator/ (a one-folder bundle). On Windows the
+# launcher is DashcamInvestigator.exe; on Linux/macOS it's DashcamInvestigator.
+#
+# ExifTool is intentionally NOT bundled: on Linux it's a Perl script and on
+# Windows users typically install it system-wide. The app probes the PATH at
+# startup (gui/app.py) and shows a helpful dialog if it's missing.
+
+import sys
+from pathlib import Path
+
+from PyInstaller.utils.hooks import collect_submodules
+
+SPEC_DIR = Path(SPECPATH).resolve()
+IS_WINDOWS = sys.platform.startswith("win")
+
+datas = [
+    (str(SPEC_DIR / "gpx.fmt"), "."),
+    (str(SPEC_DIR / "log.conf"), "."),
+    (
+        str(SPEC_DIR / "dashcam_investigator" / "gui" / "assets"),
+        "dashcam_investigator/gui/assets",
+    ),
+]
+
+binaries = []
+if IS_WINDOWS:
+    # Optional convenience: if exiftool.exe sits next to the spec, ship it.
+    bundled_exiftool = SPEC_DIR / "exiftool.exe"
+    if bundled_exiftool.is_file():
+        binaries.append((str(bundled_exiftool), "."))
+
+hiddenimports = collect_submodules("dashcam_investigator")
+
+a = Analysis(
+    [str(SPEC_DIR / "dashcam_investigator" / "__main__.py")],
+    pathex=[str(SPEC_DIR)],
+    binaries=binaries,
+    datas=datas,
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="DashcamInvestigator",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,
+    console=False,  # --windowed: no terminal on any platform
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="DashcamInvestigator",
+)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,26 @@ $ uv sync --dev
 
 The following software must be installed on the system where the application is executed:
 
-- **[ExifTool by Phil Harvey](https://exiftool.org/)** - Used to extract metadata (GPS data, timestamps, codecs) from video and image files. ExifTool must be available on the system PATH, or included with the application bundle.
-- **Video Codecs** - The application requires video codecs to support playback. Install the [K-Lite Codec Pack](https://www.codecguide.com/download_k-lite_codec_pack_basic.htm) for Windows or use your system's codec manager.
+- **[ExifTool by Phil Harvey](https://exiftool.org/)** - Used to extract metadata (GPS data, timestamps, codecs) from video and image files. ExifTool must be available on the system PATH.
+- **Video Codecs** - The application requires video codecs to support playback.
+
+**Windows:**
+
+- ExifTool: download `exiftool.exe` from [exiftool.org](https://exiftool.org/) and place it on `PATH`.
+- Codecs: install the [K-Lite Codec Pack](https://www.codecguide.com/download_k-lite_codec_pack_basic.htm).
+
+**Linux (Debian/Ubuntu):**
+
+```bash
+sudo apt install \
+  libimage-exiftool-perl \
+  gstreamer1.0-libav \
+  gstreamer1.0-plugins-good \
+  gstreamer1.0-plugins-bad \
+  gstreamer1.0-plugins-ugly
+```
+
+`QMediaPlayer` on Linux is backed by GStreamer, so the codec packages above are what makes typical dashcam streams (H.264 / H.265 / AAC) play. On Fedora the equivalent is `perl-Image-ExifTool` plus the `gstreamer1-plugin-*` family from RPM Fusion.
 
 #### Python Dependencies
 
@@ -66,32 +84,40 @@ See `pyproject.toml` for complete dependency specifications and `uv.lock` for pi
 The application uses Python's built-in `logging` module configured via `log.conf`. Logging behavior:
 
 - **Console Output** - DEBUG level and higher during development
-- **File Logs** - Written to `%LOCALAPPDATA%/DashcamInvestigator/Logs/`:
+- **File Logs** - Written to a per-user log directory:
+  - Windows: `%LOCALAPPDATA%/DashcamInvestigator/DashcamInvestigator/Logs/`
+  - Linux: `$XDG_STATE_HOME/DashcamInvestigator/log/` (typically `~/.local/state/DashcamInvestigator/log/`)
+  - macOS: `~/Library/Logs/DashcamInvestigator/`
+
+  Files in that directory:
   - `error.log` - ERROR and CRITICAL messages
   - `debug.log` - DEBUG and higher messages with module/line information
 
 #### Building Executables
 
-PyInstaller creates standalone Windows executables. The build includes ExifTool and the bundled HTML/CSS/JS assets used by the web panels:
+PyInstaller is driven by `DashcamInvestigator.spec`, which works on Windows, Linux, and macOS:
 
 ```bash
-# Build with uv
-uv run pyinstaller \
-  --clean \
-  --noconsole \
-  --add-data "gpx.fmt;." \
-  --add-data "log.conf;." \
-  --add-binary "exiftool.exe;." \
-  --add-data "dashcam_investigator/gui/assets;dashcam_investigator/gui/assets" \
-  --name DashcamInvestigator \
-  dashcam_investigator/__main__.py
+uv run pyinstaller --noconfirm --clean DashcamInvestigator.spec
 ```
 
-The `gui/assets` data dir is required — it ships the Jinja templates,
-CSS tokens, JS bridge code and inline SVG icons that every WebPanel
-loads at runtime. Without it the app launches but every panel is empty.
+The spec bundles `gpx.fmt`, `log.conf`, and the entire `gui/assets` tree (Jinja templates, CSS tokens, JS bridge, inline SVG icons — the web panels render empty without these). ExifTool is **not** bundled; users install it system-wide as described under System Requirements.
 
-**Build Output:** `dist/DashcamInvestigator/` - Standalone application directory
+**Build Output:** `dist/DashcamInvestigator/` — standalone application directory. Launch with `DashcamInvestigator.exe` (Windows) or `./DashcamInvestigator` (Linux/macOS).
+
+##### Linux: tar.gz and AppImage
+
+After running PyInstaller, package the result for distribution:
+
+```bash
+# Portable tar.gz (extract anywhere, run ./DashcamInvestigator)
+tar -czf dist/DashcamInvestigator-linux-x86_64.tar.gz -C dist DashcamInvestigator
+
+# Single-file AppImage (requires `appimagetool` on PATH)
+./packaging/linux/build_appimage.sh
+```
+
+`packaging/linux/build_appimage.sh` wraps the PyInstaller bundle in an AppDir with the `.desktop` entry and icon under `packaging/linux/`, then invokes `appimagetool` to produce `dist/DashcamInvestigator-x86_64.AppImage`. Get `appimagetool` from the [AppImageKit releases](https://github.com/AppImage/AppImageKit/releases).
 
 ### Keyboard shortcuts
 

--- a/dashcam_investigator/__main__.py
+++ b/dashcam_investigator/__main__.py
@@ -4,8 +4,10 @@ This is the entrypoint of the application that configures logging and then execu
 
 import logging
 import logging.config
-import os
+import sys
 from pathlib import Path
+
+from platformdirs import user_log_path
 
 # The dci:// URL scheme must be registered BEFORE QApplication is created,
 # which happens inside app.run(). Doing it here at import time keeps the
@@ -16,17 +18,36 @@ register_scheme()
 
 from .gui import app  # noqa: E402  (import after register_scheme on purpose)
 
-if __name__ == "__main__":
-    # Create a logs directory in AppData\Local\DashcamInvestigator if it doesn't already exist
-    appdata_local = os.getenv("LOCALAPPDATA")
-    log_path = Path(appdata_local, "DashcamInvestigator", "Logs")
-    LOG_PATH = str(log_path).replace("\\", "/")
-    if not Path(LOG_PATH).exists():
-        Path(LOG_PATH).mkdir(parents=True, exist_ok=True)
 
-    # Setup logging based on log.conf
+def _resolve_log_dir() -> Path:
+    """Per-user log directory across platforms.
+
+    Windows -> %LOCALAPPDATA%/DashcamInvestigator/Logs
+    Linux   -> $XDG_STATE_HOME/DashcamInvestigator/log (typically ~/.local/state/...)
+    macOS   -> ~/Library/Logs/DashcamInvestigator
+    """
+    return user_log_path(
+        "DashcamInvestigator", "DashcamInvestigator", ensure_exists=True
+    )
+
+
+def _resolve_log_conf() -> Path:
+    """Locate log.conf in dev checkouts and PyInstaller-frozen bundles."""
+    if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
+        return Path(sys._MEIPASS) / "log.conf"  # type: ignore[attr-defined]
+    return Path(__file__).resolve().parent.parent / "log.conf"
+
+
+if __name__ == "__main__":
+    log_dir = _resolve_log_dir()
+    # fileConfig substitutes %(logPath)s into the file handler args. Forward
+    # slashes work on every platform Python's logging module supports.
+    log_path_str = log_dir.as_posix()
+
     logging.config.fileConfig(
-        "log.conf", defaults={"logPath": LOG_PATH}, disable_existing_loggers=False
+        str(_resolve_log_conf()),
+        defaults={"logPath": log_path_str},
+        disable_existing_loggers=False,
     )
 
     logger = logging.getLogger(__name__)

--- a/packaging/linux/DashcamInvestigator.desktop
+++ b/packaging/linux/DashcamInvestigator.desktop
@@ -1,0 +1,11 @@
+[Desktop Entry]
+Type=Application
+Name=Dashcam Investigator
+GenericName=Forensic Dashcam Analyzer
+Comment=Forensic investigation of evidence gathered from dashcam devices
+Exec=DashcamInvestigator
+Icon=DashcamInvestigator
+Terminal=false
+Categories=Office;Forensics;AudioVideo;Utility;
+Keywords=forensics;dashcam;video;gps;investigation;
+StartupWMClass=DashcamInvestigator

--- a/packaging/linux/DashcamInvestigator.svg
+++ b/packaging/linux/DashcamInvestigator.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" width="256" height="256">
+  <rect width="256" height="256" rx="32" fill="#1f2937"/>
+  <g transform="translate(40 64)" fill="none" stroke="#f8fafc" stroke-width="14" stroke-linecap="round" stroke-linejoin="round">
+    <polygon points="172 6 124 40 172 74 172 6" fill="#3b82f6" stroke="#3b82f6"/>
+    <rect x="6" y="0" width="120" height="96" rx="14"/>
+    <circle cx="66" cy="48" r="20" fill="#ef4444" stroke="#ef4444"/>
+  </g>
+</svg>

--- a/packaging/linux/build_appimage.sh
+++ b/packaging/linux/build_appimage.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# Wrap the PyInstaller onedir bundle in an AppImage.
+#
+# Prereqs:
+#   - PyInstaller has already produced dist/DashcamInvestigator/
+#   - appimagetool is on PATH (download from
+#     https://github.com/AppImage/AppImageKit/releases)
+#   - Run from the repo root.
+#
+# Output: dist/DashcamInvestigator-x86_64.AppImage
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+DIST_DIR="${REPO_ROOT}/dist"
+ONEDIR="${DIST_DIR}/DashcamInvestigator"
+APPDIR="${DIST_DIR}/DashcamInvestigator.AppDir"
+PACKAGING_DIR="${REPO_ROOT}/packaging/linux"
+
+if [[ ! -d "${ONEDIR}" ]]; then
+  echo "error: ${ONEDIR} not found. Run pyinstaller first." >&2
+  exit 1
+fi
+
+if ! command -v appimagetool >/dev/null 2>&1; then
+  echo "error: appimagetool not on PATH." >&2
+  echo "Install: https://github.com/AppImage/AppImageKit/releases" >&2
+  exit 1
+fi
+
+rm -rf "${APPDIR}"
+mkdir -p "${APPDIR}/usr/bin" "${APPDIR}/usr/share/applications" \
+  "${APPDIR}/usr/share/icons/hicolor/scalable/apps"
+
+# Copy the entire PyInstaller bundle into AppDir/usr/bin so the binary,
+# its dynamically-linked Qt libs, and the bundled assets all stay together.
+cp -r "${ONEDIR}/." "${APPDIR}/usr/bin/"
+
+# Desktop entry + icon (top-level copies are required by the AppImage spec).
+cp "${PACKAGING_DIR}/DashcamInvestigator.desktop" "${APPDIR}/"
+cp "${PACKAGING_DIR}/DashcamInvestigator.desktop" \
+  "${APPDIR}/usr/share/applications/DashcamInvestigator.desktop"
+
+cp "${PACKAGING_DIR}/DashcamInvestigator.svg" "${APPDIR}/DashcamInvestigator.svg"
+cp "${PACKAGING_DIR}/DashcamInvestigator.svg" \
+  "${APPDIR}/usr/share/icons/hicolor/scalable/apps/DashcamInvestigator.svg"
+# .DirIcon is what file managers pick up for the AppImage thumbnail.
+cp "${PACKAGING_DIR}/DashcamInvestigator.svg" "${APPDIR}/.DirIcon"
+
+# AppRun is the entrypoint AppImage exec()s. Forward all args, set HERE so
+# the binary can find its sibling libs even when launched via a desktop file.
+cat > "${APPDIR}/AppRun" <<'EOF'
+#!/usr/bin/env bash
+HERE="$(dirname "$(readlink -f "${0}")")"
+export PATH="${HERE}/usr/bin:${PATH}"
+exec "${HERE}/usr/bin/DashcamInvestigator" "$@"
+EOF
+chmod +x "${APPDIR}/AppRun"
+
+ARCH="${ARCH:-$(uname -m)}"
+OUTPUT="${DIST_DIR}/DashcamInvestigator-${ARCH}.AppImage"
+
+ARCH="${ARCH}" appimagetool --no-appstream "${APPDIR}" "${OUTPUT}"
+
+echo "Built: ${OUTPUT}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "gpxpy>=1.6.0",
     "altair>=5.3.0",
     "Jinja2>=3.1.0",
+    "platformdirs>=4.0.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -305,6 +305,7 @@ dependencies = [
     { name = "numpy", version = "2.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
     { name = "pandas", version = "2.3.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
     { name = "pandas", version = "3.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "platformdirs" },
     { name = "pyside6" },
 ]
 
@@ -328,6 +329,7 @@ requires-dist = [
     { name = "jinja2", specifier = ">=3.1.0" },
     { name = "numpy", specifier = ">=1.26.0" },
     { name = "pandas", specifier = ">=2.2.0" },
+    { name = "platformdirs", specifier = ">=4.0.0" },
     { name = "pyside6", specifier = ">=6.5.0" },
 ]
 


### PR DESCRIPTION
## Summary

Makes Dashcam Investigator runnable on Linux end-to-end and produces a Linux release binary (`tar.gz` + AppImage) alongside the existing Windows `.zip`.

The app crashed on Linux/macOS at startup because `dashcam_investigator/__main__.py` resolved its log directory from `%LOCALAPPDATA%`, which is `None` outside Windows — `Path(None, ...)` raises `TypeError` before the GUI ever opens. The PyInstaller path was also Windows-only: the documented build command used `;` separators, bundled `exiftool.exe`, and the `release` CI job was pinned to `windows-latest`.

## Why

Linux users couldn't run the app from source, and there was no Linux release artifact. The codebase was already 90% cross-platform (`pathlib`, `shutil.which("exiftool")`, `subprocess` with list args, frozen-aware `assets_path()`); only the startup logging block and the build/packaging layer were Windows-locked.

## Changes

### Cross-platform runtime fix
- `dashcam_investigator/__main__.py` — resolve the log dir via `platformdirs.user_log_path(...)` so each OS gets the right place:
  - Windows → `%LOCALAPPDATA%\DashcamInvestigator\DashcamInvestigator\Logs`
  - Linux → `$XDG_STATE_HOME/DashcamInvestigator/log` (typically `~/.local/state/...`)
  - macOS → `~/Library/Logs/DashcamInvestigator`
- Resolve `log.conf` relative to `__file__` / `sys._MEIPASS` instead of CWD, so a frozen binary launched from a desktop file or AppImage finds it.
- `pyproject.toml` / `uv.lock` — promote `platformdirs` to a direct dep (it was already transitive via `black`).

### PyInstaller build
- New `DashcamInvestigator.spec` — single cross-platform spec, bundles `gpx.fmt`, `log.conf`, and `dashcam_investigator/gui/assets/`. ExifTool intentionally **not** bundled; the existing startup probe at `gui/app.py:433` already shows a friendly dialog when it's missing. (On Linux, ExifTool is a Perl script — bundling it would require packaging Perl too.) The spec optionally picks up a sibling `exiftool.exe` on Windows for parity with the old build.
- `.gitignore` — added a `!DashcamInvestigator.spec` allow-rule so the hand-written spec is tracked despite the default `*.spec` ignore.

### Linux packaging (`packaging/linux/`)
- `DashcamInvestigator.desktop` — XDG desktop entry.
- `DashcamInvestigator.svg` — application icon.
- `build_appimage.sh` — assembles an `AppDir` from the PyInstaller onedir output and runs `appimagetool` to produce `dist/DashcamInvestigator-x86_64.AppImage`.

### CI (`.github/workflows/ci.yml`)
- Replaced the windows-only `release` job with:
  - **`package`** matrix on `windows-latest` + `ubuntu-latest`. Builds with the spec, then zips on Windows / `tar.gz`s and AppImages on Linux. Linux job installs `libimage-exiftool-perl`, `gstreamer1.0-{libav,plugins-good,plugins-bad,plugins-ugly}`, `libfuse2`, and downloads `appimagetool`.
  - **`release`** job that downloads both matrix artifacts and attaches all three to the GitHub Release.
- Both gated behind the existing `workflow_dispatch` `create_release` input — no behavior change for normal pushes/PRs.

### Documentation (`README.md`)
- Per-platform System Requirements (Windows + Debian/Ubuntu apt one-liner + Fedora hint).
- Replaced the inline pyinstaller command with `uv run pyinstaller --noconfirm --clean DashcamInvestigator.spec`.
- New "Linux: tar.gz and AppImage" subsection covering the packaging script.
- Updated Logging section to list all three log directories.

## Files changed
- `dashcam_investigator/__main__.py` — cross-platform log dir + frozen-aware `log.conf` lookup.
- `pyproject.toml`, `uv.lock` — `platformdirs` direct dep.
- `DashcamInvestigator.spec` (new) — single PyInstaller spec for all platforms.
- `.gitignore` — keep the spec tracked.
- `packaging/linux/DashcamInvestigator.desktop` (new), `DashcamInvestigator.svg` (new), `build_appimage.sh` (new, exec).
- `.github/workflows/ci.yml` — `package` matrix + multi-artifact `release`.
- `README.md` — Linux setup, build, log paths.

## Trade-offs / things that didn't change
- **ExifTool stays a system dependency on Linux.** Bundling Phil Harvey's Linux ExifTool tarball would add ~20 MB and a Perl runtime; a one-line `apt install` is simpler and matches how the Windows build already worked (binary expected on PATH).
- **Codec coverage on Linux depends on installed GStreamer plugins.** The `gstreamer1.0-libav + plugins-{good,bad,ugly}` set covers H.264/H.265/AAC and the codecs typical dashcams use, but exotic streams may need additional plugins on the user's system. Documented in README.
- **Format choice.** Shipped both `tar.gz` (portable, no system integration) and AppImage (single-file, mirrors the Windows `.exe` UX). `.deb` was considered but rejected — Debian-family-only and adds a distinct packaging path for marginal benefit.

## Test plan

- [x] `uv lock` resolves cleanly (79 packages).
- [x] `uv run pytest -q` → 221 passed, 4 skipped (pre-existing skips, no regressions).
- [x] `uv run ruff check .` clean.
- [x] `uv run black --check .` clean.
- [x] `_resolve_log_dir()` returns `~/.local/state/DashcamInvestigator/log` on Linux (verified locally).
- [x] `_resolve_log_conf()` finds `log.conf` from a fresh CWD (verified locally).
- [x] `DashcamInvestigator.spec` parses as valid Python.
- [ ] **Needs a real Linux box (CI smoke):** trigger `workflow_dispatch` with `create_release=true`, confirm the `package` matrix produces `DashcamInvestigator-windows-x86_64.zip`, `DashcamInvestigator-linux-x86_64.tar.gz`, and `DashcamInvestigator-x86_64.AppImage`, and that the `release` job attaches all three.
- [ ] **Manual GUI smoke on Linux:** extract the tar.gz on Ubuntu 22.04/24.04, run `./DashcamInvestigator`, create a project, process a directory with a sample dashcam clip, confirm the Map / Metadata / Speed / Notes panels render and video plays.
- [ ] **AppImage smoke:** `chmod +x DashcamInvestigator-x86_64.AppImage && ./DashcamInvestigator-x86_64.AppImage` on a clean machine without the `tar.gz` extracted; same checks as above.
- [ ] **Windows regression check:** confirm the new spec produces a working bundle equivalent to the previous CLI invocation (drop in a sibling `exiftool.exe` and verify it ships).

https://claude.ai/code/session_01Lp8ymn6A8E6dtRp4wksyT9